### PR TITLE
delete url trailing spaces in cleanup_website method

### DIFF
--- a/src/ilcdlib/sanitizing/domain.py
+++ b/src/ilcdlib/sanitizing/domain.py
@@ -44,6 +44,7 @@ def cleanup_website(website: str | None) -> str | None:
     """
     if website is None:
         return None
+    website = website.strip()
     if not website.startswith("http"):
         return "https://" + website + "/"
     return website


### PR DESCRIPTION
some urls are parsed with trailing space, cleanup_website return invalid url and ValidationError is raised