### PR TITLE
Fixing docstring.

### DIFF
--- a/src/ilcdlib/medium/archive.py
+++ b/src/ilcdlib/medium/archive.py
@@ -108,7 +108,7 @@ class ZipIlcdReader(BaseIlcdMediumSpecificReader):
         """
         List all entities of the given type.
 
-        :param entity_type: The type of the entity. e.g. "process", "contact", "flow", etc.
+        :param entity_type: The type of the entity. e.g. "processes", "contacts", "flows", etc.
         """
         if isinstance(entity_type, IlcdDatasetType):
             entity_type_str = self.DATASET_TO_FOLDER.get(entity_type, str(entity_type))


### PR DESCRIPTION
I'm fixing the docstring because the resulting tooltips in my IDE are misleading. It suggests searching for "process", "contact" and "flow", among others. However, calling the function `zip_reader.list_entities('process')` only returns an empty list `[]`. The correct strings are listed at the beginning of the class.

```python
DATASET_TO_FOLDER: dict[IlcdDatasetType, str] = {
        IlcdDatasetType.Flows: "flows",
        IlcdDatasetType.Sources: "sources",
        IlcdDatasetType.UnitGroups: "unitgroups",
        IlcdDatasetType.Contacts: "contacts",
        IlcdDatasetType.Processes: "processes",
        IlcdDatasetType.FlowProperty: "flowproperties",
    }
```